### PR TITLE
Add a default React displayName 

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -40,6 +40,7 @@ export default class CytoscapeComponent extends React.Component {
 
   constructor(props) {
     super(props);
+    this.displayName = `CytoscapeComponent`;
   }
 
   componentDidMount() {


### PR DESCRIPTION
This PR adds a default `displayName` prop to the CytoscapeComponent, so in React DevTools it can be searched right away:

<img width="647" alt="screen shot 2019-02-01 at 11 45 01" src="https://user-images.githubusercontent.com/708395/52095597-b5572000-2617-11e9-9905-ff71f9220b23.png">

Subsequent instances of `CytoscapeComponent` can override its own `displayName` prop to differentiate themselves from each other.
