### PR TITLE
fix error where edges are drawn before nodes

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -34,7 +34,7 @@ export default class CytoscapeComponent extends React.Component {
         edges = [];
       }
 
-      return nodes.concat(edges);
+      return [...nodes,...edges];
     }
   }
 


### PR DESCRIPTION
Sometimes when updating elements using normalizeElements, the edge is trying to be drawn before the node is rendered.
This should fix that error. Not sure it is the source