### PR TITLE
Make cytoscape a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "demo": "cross-env NODE_ENV=development webpack-serve webpack.config.js --open --open-path demo.html"
   },
   "peerDependencies": {
+    "cytoscape": "^3.2.19",
     "react": ">=15.0.0",
     "react-dom": ">=15.0.0"
   },
@@ -66,7 +67,6 @@
     "node": ">=8.11.3"
   },
   "dependencies": {
-    "cytoscape": "^3.2.19",
     "prop-types": "^15.6.2"
   }
 }


### PR DESCRIPTION
Since cytoscape is used by the user of react-cytoscape, it should be a peer dependency. This prevents instances where you get multiple copies of cytoscape.

https://github.com/plotly/react-cytoscapejs/issues/21
https://github.com/plotly/react-cytoscapejs/issues/17

As mentioned, by @akx in issue 17, this is similar to having react as a peer dependency. Not having it as a peer dependency can make `cytoscapejs.use` not work, as you can end up with multiple copies of cytoscapejs (which is what prompted my opening of this issue in the first place)

FYI: This PR does not update the package-lock.json